### PR TITLE
Specify only for the branches to build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ node_js:
   - "0.10"
 
 branches:
-  - develop
-  - master
+  only:
+    - develop
+    - master
 
 script:
   - npm test


### PR DESCRIPTION
For Travis CI to figure out which branches to include or exclude, the `branches` section needs to specify either `only` or `except`
